### PR TITLE
Uses the actual vsyncer binary path when calling vsyncer docker

### DIFF
--- a/tools/docker.go
+++ b/tools/docker.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	dockerPath  = "docker"
+	dockerCmd   = "docker"
 	dockerImage = "ghcr.io/open-s4c/vsyncer"
 	dockerTag   = "latest"
 	useDocker   = "false"
@@ -40,7 +40,7 @@ func DockerRun(ctx context.Context, args []string, volumes []string) error {
 	}
 
 	// check docker installation
-	if err := exec.CommandContext(ctx, dockerPath).Run(); err != nil {
+	if err := exec.CommandContext(ctx, dockerCmd).Run(); err != nil {
 		return fmt.Errorf("could not run docker: %v", err)
 	}
 
@@ -50,7 +50,7 @@ func DockerRun(ctx context.Context, args []string, volumes []string) error {
 	}
 
 	// is it rootless?
-	if output, err := exec.CommandContext(ctx, dockerPath, "info", "-f",
+	if output, err := exec.CommandContext(ctx, dockerCmd, "info", "-f",
 		"{{println .SecurityOptions}}").Output(); err != nil {
 		return fmt.Errorf("could not run docker: %v", err)
 	} else {
@@ -86,7 +86,7 @@ func DockerRun(ctx context.Context, args []string, volumes []string) error {
 	cmd = append(cmd, args...)
 
 	// create command, start output readers and start
-	c := exec.CommandContext(ctx, dockerPath, cmd...)
+	c := exec.CommandContext(ctx, dockerCmd, cmd...)
 	if err := startReaders(c); err != nil {
 		return err
 	}

--- a/tools/environment.go
+++ b/tools/environment.go
@@ -7,10 +7,22 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"vsync/logger"
 )
+
+var vsyncerCmd string
+
+func init() {
+	if cmd, err := filepath.Abs(os.Args[0]); err != nil {
+		logger.Fatalf("could not find vsyncer path: %v", err)
+	} else {
+		vsyncerCmd = cmd
+	}
+
+}
 
 // FindCmd looks for the value of an environment variable.
 // If not set returns a default value.
@@ -22,7 +34,7 @@ func FindCmd(key string) ([]string, error) {
 
 	cmds := strings.Split(val, " ")
 	if IsDefaultEnv(key) && GetEnv("VSYNCER_DOCKER") == "true" {
-		return append([]string{"vsyncer", "docker", "--"}, cmds...), nil
+		return append([]string{vsyncerCmd, "docker", "--"}, cmds...), nil
 	}
 	return cmds, err
 }


### PR DESCRIPTION
Fixes #23 