### PR TITLE
dartagnan: map CAT spec violation as CheckNotSafe

### DIFF
--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -117,6 +117,8 @@ func (c *DartagnanChecker) Check(ctx context.Context, m DumpableModule) (cr Chec
 		return CheckResult{Status: CheckNotSafe, Output: sout}, nil
 	} else if strings.Contains(sout, "Liveness violation found") {
 		return CheckResult{Status: CheckNotLive, Output: sout}, nil
+	} else if strings.Contains(sout, "CAT specification violation found") {
+		return CheckResult{Status: CheckNotSafe, Output: sout}, nil
 	} else if strings.Contains(sout, "Verification finished with result UNKNOWN\n") {
 		text := `No violation found, but the program was not fully unrolled.
 Try increasing the unrolling bound by adding "--bound=X" (where X is the bound) to DARTAGNAN_OPTIONS.`


### PR DESCRIPTION
Dartagnan can check data races encoded in the cat files, for example, in the rc11.cat. For that one needs to pass some options to Dartagnan via DARTAGNAN_OPTIONS environment variable. If the specification in the cat file is violated, it should be mapped as a normal safety violation.