### PR TITLE
Allow default checker to be defined in envvar

### DIFF
--- a/cmd/vsyncer/check.go
+++ b/cmd/vsyncer/check.go
@@ -35,6 +35,8 @@ var checkCmd = cobra.Command{
 }
 
 func init() {
+	tools.RegEnv("VSYNCER_DEFAULT_MEMMODEL", "imm", "Default memory model")
+
 	flags := checkCmd.PersistentFlags()
 	flags.StringVar(&checkFlags.csvFile, "csv-log", "", "CSV file to append the final result to ")
 	flags.DurationVar(&checkFlags.timeout, "timeout", 0, "Check timeout, e.g., 1s for 1 second, 1m for 1 minute.\nCheck will fail if the model checker did not finish within the given time.\ntimeout 0 is equivalent to no timeout")
@@ -44,7 +46,7 @@ func init() {
 }
 
 func addCheckFlags(flags *pflag.FlagSet) {
-	flags.StringVarP(&checkFlags.memoryModel, "memory-model", "m", "imm", "memory model")
+	flags.StringVarP(&checkFlags.memoryModel, "memory-model", "m", tools.GetEnv("VSYNCER_DEFAULT_MEMMODEL"), "memory model")
 	flags.SetInterspersed(false)
 }
 

--- a/cmd/vsyncer/root.go
+++ b/cmd/vsyncer/root.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -46,6 +47,9 @@ var rootCmd = cobra.Command{
 }
 
 func init() {
+	tools.RegEnv("VSYNCER_DEFAULT_CHECKER", "genmc", "Default model checker")
+	tools.RegEnv("VSYNCER_DEFAULT_ENTRY_FUNC", "main", "Default entry functions for analysis")
+
 	helpMessage :=
 		`vsyncer -- Verification and optimization of concurrent code on WMM`
 
@@ -58,12 +62,14 @@ func init() {
 
 	flags := rootCmd.PersistentFlags()
 	flags.StringVar(&rootFlags.log, "log", "ERROR", "log level (ERROR|INFO|WARN)")
-	flags.StringVarP(&rootFlags.checker, "checker", "c", "genmc", "target checker (genmc|dartagnan|mock)")
+	flags.StringVarP(&rootFlags.checker, "checker", "c", tools.GetEnv("VSYNCER_DEFAULT_CHECKER"), "target checker (genmc|dartagnan|mock)")
 	flags.StringVarP(&rootFlags.outputFn, "output", "o", "", "output LLVM file")
 	flags.BoolVar(&rootFlags.expand, "expand", true, "expand vatomic functions")
 	flags.BoolVarP(&rootFlags.debug, "debug", "d", false, "set debug mode")
 	flags.BoolVarP(&rootFlags.quiet, "quiet", "q", false, "do not produce output")
-	flags.StringSliceVar(&rootFlags.entryFunc, "entry-func", []string{"main"}, "list of entry functions")
+	flags.StringSliceVar(&rootFlags.entryFunc, "entry-func",
+		strings.Split(tools.GetEnv("VSYNCER_DEFAULT_ENTRY_FUNC"), ","),
+		"list of entry functions")
 
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	initOptimize()

--- a/tools/environment.go
+++ b/tools/environment.go
@@ -46,7 +46,7 @@ type Envvar struct {
 }
 
 func (e Envvar) String() string {
-	return fmt.Sprintf("%s: %s (default: %s)", e.Name, e.Desc, e.Defv)
+	return fmt.Sprintf("%s: %s (fallback: %s)", e.Name, e.Desc, e.Defv)
 }
 
 var envVars = map[string]Envvar{}


### PR DESCRIPTION
Adds environment variables to configure default checker, default memory model and path to custom cat files (for dartagnan).