### PR TITLE
dartagnan: Disable libvsync spin annotation during compilation

### DIFF
--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -137,6 +137,7 @@ func init() {
 		func() []string {
 			return []string{
 				"-DVSYNC_VERIFICATION_DAT3M",
+				"-DVSYNC_DISABLE_SPIN_ANNOTATION",
 			}
 		}
 }


### PR DESCRIPTION
The spinloop annotation is not necessary for Dartagnan.