### PR TITLE
Fix foo definition in tests/function_pointer.c

### DIFF
--- a/tests/function_pointer.c
+++ b/tests/function_pointer.c
@@ -1,12 +1,12 @@
 
 int x;
 
-void foo() {
+void foo(void) {
     __atomic_store_n(&x, 1, __ATOMIC_SEQ_CST);
 }
 
 int main() {
-    void (*bar)() = foo;
+    void (*bar)(void) = foo;
 
     bar();
     int y = __atomic_load_n(&x, __ATOMIC_SEQ_CST);


### PR DESCRIPTION
In C, there is a difference between `f(void)` and `f()`. The first one declares a function which takes no parameters, the second one defines a function for which we do not know how many parameters can be passed. A more detailed discussion is given [here](https://stackoverflow.com/questions/693788/is-it-better-to-use-c-void-arguments-void-foovoid-or-not-void-foo).