### PR TITLE
Add dartagnan.getVersion()

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -8,6 +8,12 @@ import (
 	"context"
 )
 
+type Version struct {
+	major int
+	minor int
+	patch int
+}
+
 // DumpableModule represents the interface of modules required by the checkers.
 type DumpableModule interface {
 	String() string

--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -62,7 +62,7 @@ func (c *DartagnanChecker) setVersion() {
 }
 
 func (c *DartagnanChecker) GetVersion() string {
-	return fmt.Sprintf("v%d", c.version)
+	return fmt.Sprintf("v%s", c.version)
 }
 
 var models = map[MemoryModel]struct {

--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -76,7 +76,7 @@ func (c *DartagnanChecker) setVersion() {
 }
 
 func (c *DartagnanChecker) GetVersion() string {
-	return fmt.Sprintf("v%s", c.version)
+	return fmt.Sprintf("v%d.%d.%d", c.version.major, c.version.minor, c.version.patch)
 }
 
 var models = map[MemoryModel]struct {

--- a/checker/checker_genmc.go
+++ b/checker/checker_genmc.go
@@ -25,12 +25,6 @@ func init() {
 		"Path to genmc headers, e.g., genmc.h")
 }
 
-type Version struct {
-	major int
-	minor int
-	patch int
-}
-
 // GenMC is a wraps the GenMC model checker by Kokologiannakis et al.
 type GenMC struct {
 	threads uint
@@ -83,7 +77,7 @@ func (c *GenMC) setVersion(genmcCmd []string) {
 	c.version.minor, _ = strconv.Atoi(grps[2])
 	// group 3 is the optional dot so we skip it
 	c.version.patch, _ = strconv.Atoi(grps[4])
-	logger.Debugf("Detected GenMC version v%d.%d.%d\n", c.version.major, c.version.minor, c.version.patch)
+	logger.Debugf("Detected GenMC version %d.%d.%d\n", c.version.major, c.version.minor, c.version.patch)
 }
 
 func (c *GenMC) GetVersion() string {


### PR DESCRIPTION
Depends on https://github.com/hernanponcedeleon/Dat3M/pull/662.

NOTE: Running `java -jar dartagnan/target/dartagnan.jar --version` relies on having the `pom.yml` file in `DAT3M_HOME` so we will also need to update the docker container to copy that file.

EDIT: I just realized that the check status now prints
```
Assignments
  [L] Loads   : 0x00 (0b0000000)
  [S] Stores  : 0x00 (0b00000)
  [A] Atomics : 0x3 (0b11)
  [F] Fences  : 0x (0b)
  [X] RMWs    : 0x3 (0b11)

Status
  1

Elapsed time
  166.83769ms
```
even if I use genmc as the MC. I did not touch any genmc file, so I have no idea why this is the case. @db7 any idea?