### PR TITLE
Update dat3m version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,8 @@ RUN cd /tmp/dat3m \
  && mkdir -p /usr/share/dat3m/dartagnan \
  && cp -R dartagnan/target /usr/share/dat3m/dartagnan \
  && cp -R include /usr/share/dat3m \
- && cp -R cat /usr/share/dat3m
+ && cp -R cat /usr/share/dat3m \
+ && cp pom.xml /usr/share/dat3m/pom.xml
 
 ################################################################################
 # vsyncer_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,10 +67,8 @@ RUN apt-get update  \
  && rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp \
- && git clone \
-     https://github.com/hernanponcedeleon/dat3m.git \
- && cd dat3m \
- && git checkout "c48cc9f2b726f0f99947dacfbd88c99b281ff173"
+ && git clone --depth 1 --branch "4.1.0" \
+     https://github.com/hernanponcedeleon/dat3m.git
 
 RUN cd /tmp/dat3m \
  && mvn clean install -DskipTests \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN cd /tmp \
  && git clone \
      https://github.com/hernanponcedeleon/dat3m.git \
  && cd dat3m \
- && git checkout "abab4597e3035b92485a10bfd2926716ea46474a"
+ && git checkout "c48cc9f2b726f0f99947dacfbd88c99b281ff173"
 
 RUN cd /tmp/dat3m \
  && mvn clean install -DskipTests \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,10 +67,8 @@ RUN apt-get update  \
  && rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp \
- && git clone \
-     https://github.com/hernanponcedeleon/dat3m.git \
- && cd dat3m \
- && git checkout "dda0d6c4aac9810ed0a2cb3987ad937f0b729228"
+ && git clone --depth 1 --branch "4.1.0" \
+     https://github.com/hernanponcedeleon/dat3m.git
 
 RUN cd /tmp/dat3m \
  && mvn clean install -DskipTests \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN cd /tmp \
  && git clone \
      https://github.com/hernanponcedeleon/dat3m.git \
  && cd dat3m \
- && git checkout "d0a8bf33aaf2d0634515077a4a7e7ceb8f1e7e22"
+ && git checkout "4004a4ef8e49f6e05a59fb05f2040144a2c4db33"
 
 RUN cd /tmp/dat3m \
  && mvn clean install -DskipTests \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN cd /tmp \
  && git clone \
      https://github.com/hernanponcedeleon/dat3m.git \
  && cd dat3m \
- && git checkout "4004a4ef8e49f6e05a59fb05f2040144a2c4db33"
+ && git checkout "dda0d6c4aac9810ed0a2cb3987ad937f0b729228"
 
 RUN cd /tmp/dat3m \
  && mvn clean install -DskipTests \

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,7 @@ RUN apt-get update \
 
 # dat3m
 COPY --from=dat3m_builder /usr/share/dat3m /usr/share/dat3m
+COPY --from=dat3m_builder /usr/share/dat3m/pom.xml /usr/share/dat3m/pom.xml
 RUN ln -s /usr/share/dat3m/dartagnan/target/libs/*.so /usr/lib/
 ENV DAT3M_HOME=/usr/share/dat3m
 ENV DAT3M_OUTPUT="/tmp/dat3m"

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN cd /tmp \
  && git clone \
      https://github.com/hernanponcedeleon/dat3m.git \
  && cd dat3m \
- && git checkout "dd27443ccd6d2efe4e2cf2ebd9db1d2faa6fd5e5"
+ && git checkout "d0a8bf33aaf2d0634515077a4a7e7ceb8f1e7e22"
 
 RUN cd /tmp/dat3m \
  && mvn clean install -DskipTests \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,10 @@ RUN apt-get update  \
  && rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp \
- && git clone --depth 1 --branch "4.1.0" \
-     https://github.com/hernanponcedeleon/dat3m.git
+ && git clone \
+     https://github.com/hernanponcedeleon/dat3m.git \
+ && cd dat3m \
+ && git checkout "dd27443ccd6d2efe4e2cf2ebd9db1d2faa6fd5e5"
 
 RUN cd /tmp/dat3m \
  && mvn clean install -DskipTests \

--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -33,7 +33,7 @@ func init() {
 	tools.RegEnv("DARTAGNAN_SET_OPTIONS", "",
 		"Options passed to Dartagnan, replacing the default options")
 	tools.RegEnv("DARTAGNAN_CAT_PATH", "", "Path to custom .cat files")
-	tools.RegEnv("DARTAGNAN_METHOD", "lazy", "Backend method (values: eager | lazy)")
+	tools.RegEnv("DARTAGNAN_SOLVER", "yices2", "Backend SMT solver (values: cvc4 | cvc5 | yices2 | z3)")
 	tools.RegEnv("DARTAGNAN_BOUND", "", "Unroll bound integer (default unset)")
 
 	tools.RegEnv("DARTAGNAN_OPT_CMD", "opt", "Path to opt (the llvm optimizer)")
@@ -162,8 +162,8 @@ func (c *DartagnanChecker) run(ctx context.Context, testFn string) (string, erro
 		opts = strings.Split(env, " ")
 	}
 
-	if env := tools.GetEnv("DARTAGNAN_METHOD"); env != "" {
-		opts = append(opts, fmt.Sprintf("--method=%s", env))
+	if env := tools.GetEnv("DARTAGNAN_SOLVER"); env != "" {
+		opts = append(opts, fmt.Sprintf("--solver=%s", env))
 	}
 
 	if env := tools.GetEnv("DARTAGNAN_BOUND"); env != "" {

--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -148,8 +148,6 @@ func (c *DartagnanChecker) runOptimizationPass(ctx context.Context, testFn strin
 func (c *DartagnanChecker) run(ctx context.Context, testFn string) (string, error) {
 
 	opts := []string{
-		"--property=program_spec,cat_spec,liveness",
-		"--modeling.threadCreateAlwaysSucceeds=true",
 		"--encoding.wmm.idl2sat=true",
 		"--solver=yices2",
 		fmt.Sprintf("--target=%s", models[c.mm].arch),

--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -37,7 +37,7 @@ func init() {
 	tools.RegEnv("DARTAGNAN_BOUND", "", "Unroll bound integer (default unset)")
 
 	tools.RegEnv("DARTAGNAN_OPT_CMD", "opt", "Path to opt (the llvm optimizer)")
-	tools.RegEnv("DARTAGNAN_OPTFLAGS", "-mem2reg -sroa -early-cse -indvars -loop-unroll -fix-irreducible -loop-simplify -simplifycfg -gvn",
+	tools.RegEnv("DARTAGNAN_OPTFLAGS", "-mem2reg -sroa -early-cse -indvars -loop-unroll -fix-irreducible -loop-simplify",
 		"Flags passed to opt when optimizing the target file for dartagnan")
 }
 

--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -37,7 +37,7 @@ func init() {
 	tools.RegEnv("DARTAGNAN_BOUND", "", "Unroll bound integer (default unset)")
 
 	tools.RegEnv("DARTAGNAN_OPT_CMD", "opt", "Path to opt (the llvm optimizer)")
-	tools.RegEnv("DARTAGNAN_OPTFLAGS", "-mem2reg -sroa -early-cse -indvars -loop-unroll -fix-irreducible -loop-simplify",
+	tools.RegEnv("DARTAGNAN_OPTFLAGS", "",
 		"Flags passed to opt when optimizing the target file for dartagnan")
 }
 


### PR DESCRIPTION
- Use dat3m 4.1.0 in container
- Copy pom.xml to final container (used to retrieve dat3m version)
- Remove DARTAGNAN_METHOD (method can be changed using DARTAGNAN_OPTIONS if needed)
- Add DARTAGNAN_SOLVER to easily switch SMT solver
- Remove some hardcoded dat3m options