### PR TITLE
module/expander.go: fix typo

### DIFF
--- a/module/expander.go
+++ b/module/expander.go
@@ -31,7 +31,7 @@ func expandVisitor(mod *ir.Module) VisitCallback {
 
 			// ignore already expanded functions
 			if strings.Contains(fname, "__vsyncer_expand_") {
-				logger.Debugf("skiip %s", fname)
+				logger.Debugf("skip %s", fname)
 				return nil
 			}
 


### PR DESCRIPTION
Fix a small typo that is ~always present in the debug output.