### PR TITLE
Remove hardcoded solver in dartagnan_checker

### DIFF
--- a/checker/checker_dartagnan.go
+++ b/checker/checker_dartagnan.go
@@ -149,7 +149,6 @@ func (c *DartagnanChecker) run(ctx context.Context, testFn string) (string, erro
 
 	opts := []string{
 		"--encoding.wmm.idl2sat=true",
-		"--solver=yices2",
 		fmt.Sprintf("--target=%s", models[c.mm].arch),
 		catFilePath(c.mm),
 	}


### PR DESCRIPTION
If one explicitly set `DARTAGNAN_SOLVER`, two solvers options are passed to dartagnan. This PR solves this while keeping the same default configuration.