### PR TITLE
Makefile: add separate binary using :latest docker image

### DIFF
--- a/.github/workflows/release_vsyncer.yml
+++ b/.github/workflows/release_vsyncer.yml
@@ -34,6 +34,7 @@ jobs:
             USE_DOCKER="true"
 
           cp build/vsyncer build/vsyncer-${{ github.event.release.tag_name }}-linux-amd64
+          cp build/vsyncer-latest build/vsyncer-${{ github.event.release.tag_name }}-latest-linux-amd64
 
       - name: Build for Windows
         run: |
@@ -46,6 +47,7 @@ jobs:
             USE_DOCKER="true"
 
           cp build/vsyncer build/vsyncer-${{ github.event.release.tag_name }}-windows-amd64.exe
+          cp build/vsyncer-latest build/vsyncer-${{ github.event.release.tag_name }}-latest-windows-amd64.exe
 
       - name: Build for macOS amd64
         run: |
@@ -58,6 +60,7 @@ jobs:
             USE_DOCKER="true"
 
           cp build/vsyncer build/vsyncer-${{ github.event.release.tag_name }}-darwin-amd64
+          cp build/vsyncer-latest build/vsyncer-${{ github.event.release.tag_name }}-latest-darwin-amd64
 
       - name: Build for macOS arm64
         run: |
@@ -70,6 +73,7 @@ jobs:
             USE_DOCKER="true"
 
           cp build/vsyncer build/vsyncer-${{ github.event.release.tag_name }}-darwin-arm64
+          cp build/vsyncer-latest build/vsyncer-${{ github.event.release.tag_name }}-latest-darwin-arm64
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ USE_DOCKER ?= true
 LDXFLAGS    = -X main.version=$(TAG) \
               -X vsync/tools.useDocker=$(USE_DOCKER) \
               -X vsync/tools.dockerTag=$(DOCKER_TAG)
+LDXFLAGS_L   = -X main.version=$(TAG) \
+              -X vsync/tools.useDocker=$(USE_DOCKER) \
+              -X vsync/tools.dockerTag=latest
+
 LDFLAGS     = -ldflags='-extldflags=-static $(LDXFLAGS)'
+LDFLAGS_L   = -ldflags='-extldflags=-static $(LDXFLAGS_L)'
 
 SOURCES     = $(shell find -name '*.go' -not -name '*_string.go')
 GENERATED   = $(shell find -name *_string.go)
@@ -27,10 +32,11 @@ help:
 
 all: build
 
-build: generate $(BUILD)/vsyncer
+build: generate $(BUILD)/vsyncer $(BUILD)/vsyncer-latest
 
-install: $(BUILD)/vsyncer
+install: $(BUILD)/vsyncer $(BUILD)/vsyncer-latest
 	install $(BUILD)/vsyncer $(PREFIX)/bin/
+	install $(BUILD)/vsyncer-latest $(PREFIX)/bin/
 clean:
 	rm -rf $(BUILD) $(GENERATED)
 
@@ -45,6 +51,8 @@ build-dir:
 $(BUILD)/vsyncer: build-dir $(SOURCES)
 	env CGO_ENABLED=0 go build $(LDFLAGS) -o $@ ./cmd/vsyncer
 
+$(BUILD)/vsyncer-latest: build-dir $(SOURCES)
+	env CGO_ENABLED=0 go build $(LDFLAGS_L) -o $@ ./cmd/vsyncer
 ################################################################################
 # support goals
 ################################################################################


### PR DESCRIPTION
This MR adds a separate binary which uses the :latest docker image tag irrespective of the release version.