### PR TITLE
Update GenMC 0.10.1 to GenMC 0.10.2, and make it default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,30 +23,28 @@ RUN apt-get update \
 ################################################################################
 FROM builder AS genmc_builder
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-     autoconf \
-     automake \
-     make
- RUN apt install -y software-properties-common
- RUN add-apt-repository ppa:ubuntu-toolchain-r/test
- RUN apt-get update
- RUN apt install gcc-13 g++-13 -y \
- && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get install -y software-properties-common \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gcc-13 g++-13 \
+        autoconf \
+        automake \
+        make
+    && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
 # Note: The install prefix in the builder must match the install location on
 # the final image.
 
-# RUN cd /tmp \
-#  && git clone --depth 1 --branch "v0.9" \
-#      https://github.com/open-s4c/genmc.git genmc9
+RUN cd /tmp \
+ && git clone --depth 1 --branch "v0.9" \
+     https://github.com/open-s4c/genmc.git genmc9
 
-# RUN cd /tmp/genmc9 \
-#  && autoreconf --install \
-#  && ./configure --prefix=/usr/share/genmc9 \
-#  && make install -j8
+RUN cd /tmp/genmc9 \
+ && autoreconf --install \
+ && ./configure --prefix=/usr/share/genmc9 \
+ && make install -j8
 
 RUN cd /tmp \
  && git clone --depth 1 --branch "v0.10.2-a" \
@@ -57,8 +55,8 @@ RUN cd /tmp/genmc \
  && ./configure --prefix=/usr/share/genmc \
  && make install -j8
 
-RUN /usr/share/genmc/bin/genmc --version
-# RUN /usr/share/genmc9/bin/genmc --version
+RUN /usr/share/genmc10/bin/genmc --version
+RUN /usr/share/genmc9/bin/genmc --version
 ################################################################################
 # dat3m_builder
 ################################################################################
@@ -116,21 +114,19 @@ RUN cd /tmp/vsyncer \
 FROM ${FROM_IMAGE} AS final
 
 # tools
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-     clang \
-     less \
-     libclang-dev \
-     llvm \
-     llvm-dev \
-     openjdk-17-jre \
-     vim
-RUN apt install -y software-properties-common
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-RUN apt-get update
-RUN apt install gcc-13 g++-13 -y \
- && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get install -y software-properties-common \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gcc-13 g++-13 \
+        clang \
+        less \
+        libclang-dev \
+        llvm \
+        llvm-dev \
+        openjdk-17-jre \
+        vim
+    && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
 # dat3m
@@ -141,12 +137,12 @@ ENV DAT3M_HOME=/usr/share/dat3m
 ENV DAT3M_OUTPUT="/tmp/dat3m"
 
 # genmc
-# COPY --from=genmc_builder /usr/share/genmc9 /usr/share/genmc9
-COPY --from=genmc_builder /usr/share/genmc /usr/share/genmc
-ENV PATH="/usr/share/genmc/bin:$PATH"
+COPY --from=genmc_builder /usr/share/genmc9 /usr/share/genmc9
+COPY --from=genmc_builder /usr/share/genmc10 /usr/share/genmc10
+ENV PATH="/usr/share/genmc10/bin:$PATH"
 
 RUN genmc --version
-# RUN /usr/share/genmc9/bin/genmc --version
+RUN /usr/share/genmc9/bin/genmc --version
 
 # vsyncer
 COPY --from=vsyncer_builder /usr/bin/vsyncer /usr/bin/vsyncer

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,8 @@ RUN cd /tmp/genmc10 \
  && ./configure --prefix=/usr/share/genmc10 \
  && make install -j8
 
-RUN /usr/share/genmc10 --version
-RUN /usr/share/genmc9 --version
+RUN sudo /usr/share/genmc10 --version
+RUN sudo /usr/share/genmc9 --version
 ################################################################################
 # dat3m_builder
 ################################################################################
@@ -139,8 +139,8 @@ COPY --from=genmc_builder /usr/share/genmc9 /usr/share/genmc9
 COPY --from=genmc_builder /usr/share/genmc10 /usr/share/genmc10
 ENV PATH="/usr/share/genmc9/bin:$PATH"
 
-RUN /usr/share/genmc10 --version
-RUN /usr/share/genmc9 --version
+RUN sudo /usr/share/genmc10 --version
+RUN sudo /usr/share/genmc9 --version
 
 # vsyncer
 COPY --from=vsyncer_builder /usr/bin/vsyncer /usr/bin/vsyncer

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,15 @@ RUN apt-get update \
      autoconf \
      automake \
      make \
- && rm -rf /var/lib/apt/lists/* \
  && add-apt-repository ppa:ubuntu-toolchain-r/test \
  && apt-get update \
  && apt install gcc-12 g++-12 gcc-13 g++-13 -y \
- && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 --slave /usr/bin/g++ g++ /usr/bin/g++-12 \
- && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
- && gcc --version
-
+ && rm -rf /var/lib/apt/lists/*
+ 
+RUN  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 --slave /usr/bin/g++ g++ /usr/bin/g++-12 \
+     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
+     
+RUN gcc --version
 
 RUN llvm-config --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ RUN cd /tmp/genmc10 \
  && ./configure --prefix=/usr/share/genmc10 \
  && make install -j8
 
+RUN /usr/share/genmc10 --version
+RUN /usr/share/genmc9 --version
 ################################################################################
 # dat3m_builder
 ################################################################################
@@ -136,6 +138,9 @@ ENV DAT3M_OUTPUT="/tmp/dat3m"
 COPY --from=genmc_builder /usr/share/genmc9 /usr/share/genmc9
 COPY --from=genmc_builder /usr/share/genmc10 /usr/share/genmc10
 ENV PATH="/usr/share/genmc9/bin:$PATH"
+
+RUN /usr/share/genmc10 --version
+RUN /usr/share/genmc9 --version
 
 # vsyncer
 COPY --from=vsyncer_builder /usr/bin/vsyncer /usr/bin/vsyncer

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
      make \
  && rm -rf /var/lib/apt/lists/*
 
-RUN gcc --version
+
 RUN llvm-config --version
 
 # Note: The install prefix in the builder must match the install location on

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get install -y software-properties-common \
         gcc-13 g++-13 \
         autoconf \
         automake \
-        make
+        make \
     && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
@@ -125,7 +125,7 @@ RUN apt-get install -y software-properties-common \
         llvm \
         llvm-dev \
         openjdk-17-jre \
-        vim
+        vim \
     && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,13 @@ RUN sudo apt-get update \
 # genmc_builder
 ################################################################################
 FROM builder AS genmc_builder
-
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+USER root
+RUN sudo apt-get update \
+ && sudo apt-get install -y --no-install-recommends \
      autoconf \
      automake \
      make \
- && rm -rf /var/lib/apt/lists/*
+ && sudo rm -rf /var/lib/apt/lists/*
 
 # Note: The install prefix in the builder must match the install location on
 # the final image.
@@ -53,16 +53,16 @@ RUN cd /tmp/genmc10 \
 # dat3m_builder
 ################################################################################
 FROM builder AS dat3m_builder
-
-RUN apt-get update  \
- && apt-get install -y --no-install-recommends \
+USER root
+RUN sudo apt-get update  \
+ && sudo apt-get install -y --no-install-recommends \
      graphviz \
      maven \
      autoconf \
      automake  \
      openjdk-17-jdk \
      openjdk-17-jre \
- && rm -rf /var/lib/apt/lists/*
+ && sudo rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp \
  && git clone --depth 1 --branch "4.2.0" \
@@ -80,13 +80,13 @@ RUN cd /tmp/dat3m \
 # vsyncer_builder
 ################################################################################
 FROM builder AS vsyncer_builder
-
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+USER root
+RUN sudo apt-get update \
+ && sudo apt-get install -y --no-install-recommends \
      golang-go \
      make \
      git \
- && rm -rf /var/lib/apt/lists/*
+ && sudo rm -rf /var/lib/apt/lists/*
 
 ARG VSYNCER_TAG=main
 RUN cd /tmp \
@@ -104,14 +104,14 @@ RUN cd /tmp/vsyncer \
 # vsyncer image
 ################################################################################
 FROM ${FROM_IMAGE} AS final
-
+USER root
 # tools
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+RUN sudo apt-get update \
+ && sudo apt-get install -y --no-install-recommends \
      less \
      openjdk-17-jre \
      vim \
- && rm -rf /var/lib/apt/lists/*
+ && sudo rm -rf /var/lib/apt/lists/*
 
 # dat3m
 COPY --from=dat3m_builder /usr/share/dat3m /usr/share/dat3m

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ FROM ${FROM_IMAGE} as builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-     clang \
-     libclang-dev \
-     llvm \
-     llvm-dev \
      git \
      libz-dev \
      ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Add LLVM repository
-RUN wget https://apt.llvm.org/llvm.sh
-RUN ls && bash -c llvm.sh
+RUN cd /tmp && wget https://apt.llvm.org/llvm.sh && ls
+RUN bash -c /tmp/llvm.sh
 RUN apt update
 RUN apt install -y llvm-14 clang-14 lldb-14 lld-14 clangd-14 libllvm14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update \
 ################################################################################
 FROM builder AS genmc_builder
 
-RUN apt-get install -y software-properties-common \
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
     && add-apt-repository ppa:ubuntu-toolchain-r/test \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -114,7 +115,8 @@ RUN cd /tmp/vsyncer \
 FROM ${FROM_IMAGE} AS final
 
 # tools
-RUN apt-get install -y software-properties-common \
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
     && add-apt-repository ppa:ubuntu-toolchain-r/test \
     && apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ ARG FROM_IMAGE=ghcr.io/enzymead/enzyme-dev-docker/ubuntu-22-llvm-14:1.44
 ################################################################################
 FROM ${FROM_IMAGE} as builder
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-     git \
-     libz-dev \
-     ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update \
+# && apt-get install -y --no-install-recommends \
+#     git \
+#     libz-dev \
+#     ca-certificates \
+# && rm -rf /var/lib/apt/lists/*
 
 ################################################################################
 # genmc_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,26 @@ FROM ${FROM_IMAGE} as builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-     clang \
-     libclang-dev \
-     llvm \
-     llvm-dev \
+     wget \
+     curl \
+     gnupg \
+     lsb-release \
      git \
      libz-dev \
      ca-certificates \
  && rm -rf /var/lib/apt/lists/*
+
+# Add LLVM repository
+RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" && \
+    apt update && \
+    apt install -y llvm-14 clang-14 lldb-14 lld-14 clangd-14 libllvm14
+
+# Set default clang and llvm to version 14
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 100 && \
+    update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-14 100
+
+RUN llvm-config --version
 
 ################################################################################
 # genmc_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ RUN apt-get update \
  && software-properties-common \
      autoconf \
      automake \
-     make \
- && add-apt-repository ppa:ubuntu-toolchain-r/test \
- && apt-get update \
- && apt install gcc-12 g++-12 gcc-13 g++-13 -y \
+     make 
+ RUN add-apt-repository ppa:ubuntu-toolchain-r/test 
+ RUN apt-get update
+ RUN apt install gcc-12 g++-12 gcc-13 g++-13 -y \
  && rm -rf /var/lib/apt/lists/*
  
 RUN  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 --slave /usr/bin/g++ g++ /usr/bin/g++-12 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN cd /tmp/genmc9 \
  && make install -j8
 
 RUN cd /tmp \
- && git clone --depth 1 --branch "v0.10.1-a" \
+ && git clone --depth 1 --branch "master" \
      https://github.com/open-s4c/genmc.git genmc10
 
 RUN cd /tmp/genmc10 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Add LLVM repository
-RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+RUN wget https://apt.llvm.org/llvm.sh
+RUN ls && bash -c llvm.sh
 RUN apt update
 RUN apt install -y llvm-14 clang-14 lldb-14 lld-14 clangd-14 libllvm14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ FROM ${FROM_IMAGE} AS builder
 
 USER root
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+RUN sudo apt-get update \
+ && sudo apt-get install -y --no-install-recommends \
      git \
      libz-dev \
      ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+ && sudo rm -rf /var/lib/apt/lists/*
 
 ################################################################################
 # genmc_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG FROM_IMAGE=ubuntu:22.04
 ################################################################################
 # builder image
 ################################################################################
-FROM ${FROM_IMAGE} as builder
+FROM ${FROM_IMAGE} AS builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -21,7 +21,7 @@ RUN apt-get update \
 ################################################################################
 # genmc_builder
 ################################################################################
-FROM builder as genmc_builder
+FROM builder AS genmc_builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -29,13 +29,12 @@ RUN apt-get update \
      automake \
      make
  RUN apt install -y software-properties-common
- RUN add-apt-repository ppa:ubuntu-toolchain-r/test 
+ RUN add-apt-repository ppa:ubuntu-toolchain-r/test
  RUN apt-get update
- RUN apt install gcc-12 g++-12 gcc-13 g++-13 -y \
+ RUN apt install gcc-13 g++-13 -y \
  && rm -rf /var/lib/apt/lists/*
- 
-RUN  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 --slave /usr/bin/g++ g++ /usr/bin/g++-12 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13 
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
 # Note: The install prefix in the builder must match the install location on
 # the final image.
@@ -61,7 +60,7 @@ RUN cd /tmp/genmc10 \
 ################################################################################
 # dat3m_builder
 ################################################################################
-FROM builder as dat3m_builder
+FROM builder AS dat3m_builder
 
 RUN apt-get update  \
  && apt-get install -y --no-install-recommends \
@@ -88,7 +87,7 @@ RUN cd /tmp/dat3m \
 ################################################################################
 # vsyncer_builder
 ################################################################################
-FROM builder as vsyncer_builder
+FROM builder AS vsyncer_builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -112,7 +111,7 @@ RUN cd /tmp/vsyncer \
 ################################################################################
 # vsyncer image
 ################################################################################
-FROM ${FROM_IMAGE} as final
+FROM ${FROM_IMAGE} AS final
 
 # tools
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,11 +108,7 @@ FROM ${FROM_IMAGE} AS final
 # tools
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-     clang \
      less \
-     libclang-dev \
-     llvm \
-     llvm-dev \
      openjdk-17-jre \
      vim \
  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,8 @@ RUN apt-get update \
  RUN apt install gcc-12 g++-12 gcc-13 g++-13 -y \
  && rm -rf /var/lib/apt/lists/*
  
-RUN  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 --slave /usr/bin/g++ g++ /usr/bin/g++-12 \
-     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
-     
-RUN gcc --version
-
-RUN llvm-config --version
+RUN  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 --slave /usr/bin/g++ g++ /usr/bin/g++-12 
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13 
 
 # Note: The install prefix in the builder must match the install location on
 # the final image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ ARG FROM_IMAGE=ghcr.io/enzymead/enzyme-dev-docker/ubuntu-22-llvm-14:1.44
 ################################################################################
 FROM ${FROM_IMAGE} as builder
 
-# RUN apt-get update \
-# && apt-get install -y --no-install-recommends \
-#     git \
-#     libz-dev \
-#     ca-certificates \
-# && rm -rf /var/lib/apt/lists/*
+USER root
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+     git \
+     libz-dev \
+     ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
 
 ################################################################################
 # genmc_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,8 +124,14 @@ RUN apt-get update \
      llvm \
      llvm-dev \
      openjdk-17-jre \
-     vim \
+     vim
+RUN apt install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update
+RUN apt install gcc-13 g++-13 -y \
  && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
 # dat3m
 COPY --from=dat3m_builder /usr/share/dat3m /usr/share/dat3m

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Add LLVM repository
-RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" && \
-    apt update && \
-    apt install -y llvm-14 clang-14 lldb-14 lld-14 clangd-14 libllvm14
+RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+RUN apt update
+RUN apt install -y llvm-14 clang-14 lldb-14 lld-14 clangd-14 libllvm14
 
 # Set default clang and llvm to version 14
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG FROM_IMAGE=ghcr.io/enzymead/enzyme-dev-docker/ubuntu-22-llvm-14:1.44
 ################################################################################
 # builder image
 ################################################################################
-FROM ${FROM_IMAGE} as builder
+FROM ${FROM_IMAGE} AS builder
 
 USER root
 
@@ -19,7 +19,7 @@ RUN apt-get update \
 ################################################################################
 # genmc_builder
 ################################################################################
-FROM builder as genmc_builder
+FROM builder AS genmc_builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -52,7 +52,7 @@ RUN cd /tmp/genmc10 \
 ################################################################################
 # dat3m_builder
 ################################################################################
-FROM builder as dat3m_builder
+FROM builder AS dat3m_builder
 
 RUN apt-get update  \
  && apt-get install -y --no-install-recommends \
@@ -79,7 +79,7 @@ RUN cd /tmp/dat3m \
 ################################################################################
 # vsyncer_builder
 ################################################################################
-FROM builder as vsyncer_builder
+FROM builder AS vsyncer_builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -103,7 +103,7 @@ RUN cd /tmp/vsyncer \
 ################################################################################
 # vsyncer image
 ################################################################################
-FROM ${FROM_IMAGE} as final
+FROM ${FROM_IMAGE} AS final
 
 # tools
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,17 @@ FROM builder as genmc_builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
+ && software-properties-common \
      autoconf \
      automake \
      make \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && add-apt-repository ppa:ubuntu-toolchain-r/test \
+ && apt-get update \
+ && apt install gcc-12 g++-12 gcc-13 g++-13 -y \
+ && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 --slave /usr/bin/g++ g++ /usr/bin/g++-12 \
+ && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
+ && gcc --version
 
 
 RUN llvm-config --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Add LLVM repository
-RUN cd /tmp && wget https://apt.llvm.org/llvm.sh && ls
-RUN bash -c /tmp/llvm.sh
+RUN cd /tmp && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && bash -c llvm.sh
 RUN apt update
 RUN apt install -y llvm-14 clang-14 lldb-14 lld-14 clangd-14 libllvm14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd /tmp/genmc9 \
  && make install -j8
 
 RUN cd /tmp \
- && git clone --depth 1 --branch "v0.10.1-a" \
+ && git clone --depth 1 --branch "master" \
      https://github.com/open-s4c/genmc.git genmc10
 
 RUN cd /tmp/genmc10 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,8 @@ RUN cd /tmp/genmc10 \
  && ./configure --prefix=/usr/share/genmc10 \
  && make install -j8
 
-RUN sudo /usr/share/genmc10 --version
-RUN sudo /usr/share/genmc9 --version
+RUN sudo /usr/share/genmc10/bin/genmc --version
+RUN sudo /usr/share/genmc9/bin/genmc --version
 ################################################################################
 # dat3m_builder
 ################################################################################
@@ -139,8 +139,8 @@ COPY --from=genmc_builder /usr/share/genmc9 /usr/share/genmc9
 COPY --from=genmc_builder /usr/share/genmc10 /usr/share/genmc10
 ENV PATH="/usr/share/genmc9/bin:$PATH"
 
-RUN sudo /usr/share/genmc10 --version
-RUN sudo /usr/share/genmc9 --version
+RUN sudo /usr/share/genmc10/bin/genmc --version
+RUN sudo /usr/share/genmc9/bin/genmc --version
 
 # vsyncer
 COPY --from=vsyncer_builder /usr/bin/vsyncer /usr/bin/vsyncer

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN cd /tmp/genmc9 \
  && make install -j8
 
 RUN cd /tmp \
- && git clone --depth 1 --branch "master" \
+ && git clone --depth 1 --branch "v0.10.2-a" \
      https://github.com/open-s4c/genmc.git genmc10
 
 RUN cd /tmp/genmc10 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a multi-stage dockerfile to build vsyncer and its dependencies
 
-ARG FROM_IMAGE=ubuntu:22.04
+ARG ghcr.io/enzymead/enzyme-dev-docker/ubuntu-22-llvm-14:1.44
 
 ################################################################################
 # builder image
@@ -9,26 +9,14 @@ FROM ${FROM_IMAGE} as builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-     wget \
-     curl \
-     gnupg \
-     lsb-release \
+     clang \
+     libclang-dev \
+     llvm \
+     llvm-dev \
      git \
      libz-dev \
      ca-certificates \
  && rm -rf /var/lib/apt/lists/*
-
-# Add LLVM repository
-RUN cd /tmp && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && bash -c llvm.sh
-RUN apt update
-RUN apt install -y llvm-14 clang-14 lldb-14 lld-14 clangd-14 libllvm14
-
-# Set default clang and llvm to version 14
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100 && \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 100 && \
-    update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-14 100
-
-RUN llvm-config --version
 
 ################################################################################
 # genmc_builder
@@ -55,7 +43,7 @@ RUN cd /tmp/genmc9 \
  && make install -j8
 
 RUN cd /tmp \
- && git clone --depth 1 --branch "master" \
+ && git clone --depth 1 --branch "v0.10.1-a" \
      https://github.com/open-s4c/genmc.git genmc10
 
 RUN cd /tmp/genmc10 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ FROM builder as genmc_builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
- && software-properties-common \
      autoconf \
      automake \
-     make 
+     make
+ RUN apt install -y software-properties-common
  RUN add-apt-repository ppa:ubuntu-toolchain-r/test 
  RUN apt-get update
  RUN apt install gcc-12 g++-12 gcc-13 g++-13 -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,26 +39,26 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /u
 # Note: The install prefix in the builder must match the install location on
 # the final image.
 
-RUN cd /tmp \
- && git clone --depth 1 --branch "v0.9" \
-     https://github.com/open-s4c/genmc.git genmc9
+# RUN cd /tmp \
+#  && git clone --depth 1 --branch "v0.9" \
+#      https://github.com/open-s4c/genmc.git genmc9
 
-RUN cd /tmp/genmc9 \
- && autoreconf --install \
- && ./configure --prefix=/usr/share/genmc9 \
- && make install -j8
+# RUN cd /tmp/genmc9 \
+#  && autoreconf --install \
+#  && ./configure --prefix=/usr/share/genmc9 \
+#  && make install -j8
 
 RUN cd /tmp \
  && git clone --depth 1 --branch "v0.10.2-a" \
-     https://github.com/open-s4c/genmc.git genmc10
+     https://github.com/open-s4c/genmc.git genmc
 
-RUN cd /tmp/genmc10 \
+RUN cd /tmp/genmc \
  && autoreconf --install \
- && ./configure --prefix=/usr/share/genmc10 \
+ && ./configure --prefix=/usr/share/genmc \
  && make install -j8
 
-RUN /usr/share/genmc10/bin/genmc --version
-RUN /usr/share/genmc9/bin/genmc --version
+RUN /usr/share/genmc/bin/genmc --version
+# RUN /usr/share/genmc9/bin/genmc --version
 ################################################################################
 # dat3m_builder
 ################################################################################
@@ -141,12 +141,12 @@ ENV DAT3M_HOME=/usr/share/dat3m
 ENV DAT3M_OUTPUT="/tmp/dat3m"
 
 # genmc
-COPY --from=genmc_builder /usr/share/genmc9 /usr/share/genmc9
-COPY --from=genmc_builder /usr/share/genmc10 /usr/share/genmc10
-ENV PATH="/usr/share/genmc9/bin:$PATH"
+# COPY --from=genmc_builder /usr/share/genmc9 /usr/share/genmc9
+COPY --from=genmc_builder /usr/share/genmc /usr/share/genmc
+ENV PATH="/usr/share/genmc/bin:$PATH"
 
-RUN /usr/share/genmc10/bin/genmc --version
-RUN /usr/share/genmc9/bin/genmc --version
+RUN genmc --version
+# RUN /usr/share/genmc9/bin/genmc --version
 
 # vsyncer
 COPY --from=vsyncer_builder /usr/bin/vsyncer /usr/bin/vsyncer

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
  RUN apt install -y software-properties-common
  RUN add-apt-repository ppa:ubuntu-toolchain-r/test
  RUN apt-get update
- RUN apt install gcc-13 g++-13 -y \
+ RUN apt install gcc-13 g++-13 libstdc++6 -y \
  && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN cd /tmp \
 
 RUN cd /tmp/genmc \
  && autoreconf --install \
- && ./configure --prefix=/usr/share/genmc \
+ && ./configure --prefix=/usr/share/genmc10 \
  && make install -j8
 
 RUN /usr/share/genmc10/bin/genmc --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
  RUN apt install -y software-properties-common
  RUN add-apt-repository ppa:ubuntu-toolchain-r/test
  RUN apt-get update
- RUN apt install gcc-13 g++-13 libstdc++6 -y \
+ RUN apt install gcc-13 g++-13 -y \
  && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
@@ -57,8 +57,8 @@ RUN cd /tmp/genmc10 \
  && ./configure --prefix=/usr/share/genmc10 \
  && make install -j8
 
-RUN sudo /usr/share/genmc10/bin/genmc --version
-RUN sudo /usr/share/genmc9/bin/genmc --version
+RUN /usr/share/genmc10/bin/genmc --version
+RUN /usr/share/genmc9/bin/genmc --version
 ################################################################################
 # dat3m_builder
 ################################################################################
@@ -139,8 +139,8 @@ COPY --from=genmc_builder /usr/share/genmc9 /usr/share/genmc9
 COPY --from=genmc_builder /usr/share/genmc10 /usr/share/genmc10
 ENV PATH="/usr/share/genmc9/bin:$PATH"
 
-RUN sudo /usr/share/genmc10/bin/genmc --version
-RUN sudo /usr/share/genmc9/bin/genmc --version
+RUN /usr/share/genmc10/bin/genmc --version
+RUN /usr/share/genmc9/bin/genmc --version
 
 # vsyncer
 COPY --from=vsyncer_builder /usr/bin/vsyncer /usr/bin/vsyncer

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN sudo apt-get update \
      ca-certificates \
  && sudo rm -rf /var/lib/apt/lists/*
 
+ RUN sudo ln -s /usr/bin/llvm-config-14 /usr/bin/llvm-config
+ RUN llvm-config --version
+
 ################################################################################
 # genmc_builder
 ################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a multi-stage dockerfile to build vsyncer and its dependencies
 
-ARG ghcr.io/enzymead/enzyme-dev-docker/ubuntu-22-llvm-14:1.44
+ARG FROM_IMAGE=ghcr.io/enzymead/enzyme-dev-docker/ubuntu-22-llvm-14:1.44
 
 ################################################################################
 # builder image


### PR DESCRIPTION
Change

- update GenMC 0.10.1 to GenMC 0.10.2
- make GenMC 0.10 the default GenMC in the docker instead of GenMC 0.9
- add gcc 13 to the docker, the new GenMC version does not compile with gcc 11.
